### PR TITLE
Deactivated Tab/4-Space replacement when `inlineSuggestionVisible` to support GitHub CoPilot

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
         "args": {
           "text": "    "
         },
-        "when": "editorTextFocus && editorLangId == robotframework && !editorHasSelection && !inSnippetMode && !suggestWidgetVisible && config.robotcode.editor.4SpacesTab"
+				"when": "!inlineSuggestionVisible && editorTextFocus && editorLangId == robotframework && !editorHasSelection && !inSnippetMode && !suggestWidgetVisible && config.robotcode.editor.4SpacesTab"
       }
     ],
     "configuration": [

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
         "args": {
           "text": "    "
         },
-				"when": "!inlineSuggestionVisible && editorTextFocus && editorLangId == robotframework && !editorHasSelection && !inSnippetMode && !suggestWidgetVisible && config.robotcode.editor.4SpacesTab"
+        "when": "!inlineSuggestionVisible && editorTextFocus && editorLangId == robotframework && !editorHasSelection && !inSnippetMode && !suggestWidgetVisible && config.robotcode.editor.4SpacesTab"
       }
     ],
     "configuration": [


### PR DESCRIPTION
GitHub Copilot uses inline suggestions in VSCode.
Therefore we should not add 4 spaces when they are visible.