### PR TITLE
Update diagnostic for Robocop 4.0 release after disablers module was rewritten

### DIFF
--- a/packages/language_server/src/robotcode/language_server/robotframework/parts/robocop_diagnostics.py
+++ b/packages/language_server/src/robotcode/language_server/robotframework/parts/robocop_diagnostics.py
@@ -104,7 +104,11 @@ class RobotRoboCopDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
                 async def run_check(self, ast_model, filename, source=None):  # type: ignore
                     await check_canceled()
 
-                    if robocop_version >= (2, 4):
+                    if robocop_version >= (4, 0):
+                        from robocop.utils.disablers import DisablersFinder
+
+                        disablers = DisablersFinder(ast_model)
+                    elif robocop_version >= (2, 4):
                         from robocop.utils import DisablersFinder
 
                         disablers = DisablersFinder(filename=filename, source=source)


### PR DESCRIPTION
We're getting ready to release Robocop 4.0. However I remember you have custom code to handle Robocop scans - and this code will not work after the release. Disablers module was rewritten and now instead of parsing the file as text file it parses it as Robot Framework file (so the disablers are context aware ie. disabler defined in the FOR loop will be re-enabled after the loop).

I'm not aware of your project setup so I didn't add any tests, didn't run anything except precommits etc.