### PR TITLE
Fix language-server installation command in CLI docs

### DIFF
--- a/docs/03_reference/cli.md
+++ b/docs/03_reference/cli.md
@@ -49,7 +49,7 @@ pip install robotcode[runner]
 pip install robotcode[analyze]
 pip install robotcode[debugger]
 pip install robotcode[repl]
-pip install robotcode[language-server]
+pip install robotcode[languageserver]
 ```
 
 To install all packages, including optional dependencies, use:


### PR DESCRIPTION
This pull request updates the documentation to correct the installation command for the language server extra in `robotcode`. The change ensures users use the correct extra name when installing the package.

- Documentation update:
  * Corrected the installation command in `docs/03_reference/cli.md` to use `robotcode[languageserver]` instead of the incorrect `robotcode[language-server]`.

Closes #504 