### PR TITLE
feat(perf): enhance performance by improving disk caching and applying other optimizations 

### DIFF
--- a/packages/language_server/src/robotcode/language_server/robotframework/parts/diagnostics.py
+++ b/packages/language_server/src/robotcode/language_server/robotframework/parts/diagnostics.py
@@ -46,33 +46,25 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
         self.parent.diagnostics.collect.add(self.collect_unused_keyword_references)
         self.parent.diagnostics.collect.add(self.collect_unused_variable_references)
 
-        self.parent.diagnostics.on_get_related_documents.add(
-            self._on_get_related_documents
-        )
+        self.parent.diagnostics.on_get_related_documents.add(self._on_get_related_documents)
 
     def _on_initialized(self, sender: Any) -> None:
         self.parent.diagnostics.analyze.add(self.analyze)
-        self.parent.documents_cache.namespace_initialized(
-            self._on_namespace_initialized
-        )
+        self.parent.documents_cache.namespace_initialized(self._on_namespace_initialized)
         self.parent.documents_cache.libraries_changed.add(self._on_libraries_changed)
         self.parent.documents_cache.variables_changed.add(self._on_variables_changed)
 
     def _on_libraries_changed(self, sender: Any, libraries: List[LibraryDoc]) -> None:
         docs_to_refresh: set[TextDocument] = set()
         for lib_doc in libraries:
-            docs_to_refresh.update(
-                self.parent.documents_cache.get_library_users(lib_doc)
-            )
+            docs_to_refresh.update(self.parent.documents_cache.get_library_users(lib_doc))
         for doc in docs_to_refresh:
             self.parent.diagnostics.force_refresh_document(doc)
 
     def _on_variables_changed(self, sender: Any, variables: List[LibraryDoc]) -> None:
         docs_to_refresh: set[TextDocument] = set()
         for var_doc in variables:
-            docs_to_refresh.update(
-                self.parent.documents_cache.get_variables_users(var_doc)
-            )
+            docs_to_refresh.update(self.parent.documents_cache.get_variables_users(var_doc))
         for doc in docs_to_refresh:
             self.parent.diagnostics.force_refresh_document(doc)
 
@@ -86,21 +78,15 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
             self.parent.diagnostics.force_refresh_document(namespace.document)
 
     @language_id("robotframework")
-    def _on_get_related_documents(
-        self, sender: Any, document: TextDocument
-    ) -> Optional[List[TextDocument]]:
+    def _on_get_related_documents(self, sender: Any, document: TextDocument) -> Optional[List[TextDocument]]:
         namespace = self.parent.documents_cache.get_only_initialized_namespace(document)
         if namespace is None:
             return None
         source = str(document.uri.to_path())
         return self.parent.documents_cache.get_importers(source)
 
-    def modify_diagnostics(
-        self, document: TextDocument, diagnostics: List[Diagnostic]
-    ) -> List[Diagnostic]:
-        return self.parent.documents_cache.get_diagnostic_modifier(
-            document
-        ).modify_diagnostics(diagnostics)
+    def modify_diagnostics(self, document: TextDocument, diagnostics: List[Diagnostic]) -> List[Diagnostic]:
+        return self.parent.documents_cache.get_diagnostic_modifier(document).modify_diagnostics(diagnostics)
 
     @language_id("robotframework")
     def collect_namespace_diagnostics(
@@ -191,9 +177,7 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
 
         return self._collect_unused_keyword_references(document)
 
-    def _collect_unused_keyword_references(
-        self, document: TextDocument
-    ) -> DiagnosticsResult:
+    def _collect_unused_keyword_references(self, document: TextDocument) -> DiagnosticsResult:
         try:
             namespace = self.parent.documents_cache.get_namespace(document)
 
@@ -253,15 +237,11 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
             return DiagnosticsResult(self.collect_unused_variable_references, [])
 
         if diagnostics_type != DiagnosticsCollectType.SLOW:
-            return DiagnosticsResult(
-                self.collect_unused_variable_references, None, True
-            )
+            return DiagnosticsResult(self.collect_unused_variable_references, None, True)
 
         return self._collect_unused_variable_references(document)
 
-    def _collect_unused_variable_references(
-        self, document: TextDocument
-    ) -> DiagnosticsResult:
+    def _collect_unused_variable_references(self, document: TextDocument) -> DiagnosticsResult:
         try:
             namespace = self.parent.documents_cache.get_namespace(document)
 
@@ -280,11 +260,7 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
                 ):
                     continue
 
-                if (
-                    var.name_token is not None
-                    and var.name_token.value
-                    and var.name_token.value.startswith("_")
-                ):
+                if var.name_token is not None and var.name_token.value and var.name_token.value.startswith("_"):
                     continue
 
                 if not self._is_variable_used_anywhere(document, var, namespace):

--- a/packages/language_server/src/robotcode/language_server/robotframework/parts/diagnostics.py
+++ b/packages/language_server/src/robotcode/language_server/robotframework/parts/diagnostics.py
@@ -45,29 +45,35 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
         self.parent.diagnostics.collect.add(self.collect_unused_keyword_references)
         self.parent.diagnostics.collect.add(self.collect_unused_variable_references)
 
-        self.parent.diagnostics.on_get_related_documents.add(self._on_get_related_documents)
+        self.parent.diagnostics.on_get_related_documents.add(
+            self._on_get_related_documents
+        )
 
     def _on_initialized(self, sender: Any) -> None:
         self.parent.diagnostics.analyze.add(self.analyze)
-        self.parent.documents_cache.namespace_initialized(self._on_namespace_initialized)
+        self.parent.documents_cache.namespace_initialized(
+            self._on_namespace_initialized
+        )
         self.parent.documents_cache.libraries_changed.add(self._on_libraries_changed)
         self.parent.documents_cache.variables_changed.add(self._on_variables_changed)
 
     def _on_libraries_changed(self, sender: Any, libraries: List[LibraryDoc]) -> None:
-        for doc in self.parent.documents.documents:
-            namespace = self.parent.documents_cache.get_only_initialized_namespace(doc)
-            if namespace is not None:
-                lib_docs = (e.library_doc for e in namespace.get_libraries().values())
-                if any(lib_doc in lib_docs for lib_doc in libraries):
-                    self.parent.diagnostics.force_refresh_document(doc)
+        docs_to_refresh: set[TextDocument] = set()
+        for lib_doc in libraries:
+            docs_to_refresh.update(
+                self.parent.documents_cache.get_library_users(lib_doc)
+            )
+        for doc in docs_to_refresh:
+            self.parent.diagnostics.force_refresh_document(doc)
 
     def _on_variables_changed(self, sender: Any, variables: List[LibraryDoc]) -> None:
-        for doc in self.parent.documents.documents:
-            namespace = self.parent.documents_cache.get_only_initialized_namespace(doc)
-            if namespace is not None:
-                lib_docs = (e.library_doc for e in namespace.get_variables_imports().values())
-                if any(lib_doc in lib_docs for lib_doc in variables):
-                    self.parent.diagnostics.force_refresh_document(doc)
+        docs_to_refresh: set[TextDocument] = set()
+        for var_doc in variables:
+            docs_to_refresh.update(
+                self.parent.documents_cache.get_variables_users(var_doc)
+            )
+        for doc in docs_to_refresh:
+            self.parent.diagnostics.force_refresh_document(doc)
 
     @language_id("robotframework")
     def analyze(self, sender: Any, document: TextDocument) -> None:
@@ -79,41 +85,35 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
             self.parent.diagnostics.force_refresh_document(namespace.document)
 
     @language_id("robotframework")
-    def _on_get_related_documents(self, sender: Any, document: TextDocument) -> Optional[List[TextDocument]]:
+    def _on_get_related_documents(
+        self, sender: Any, document: TextDocument
+    ) -> Optional[List[TextDocument]]:
         namespace = self.parent.documents_cache.get_only_initialized_namespace(document)
         if namespace is None:
             return None
+        source = str(document.uri.to_path())
+        return self.parent.documents_cache.get_importers(source)
 
-        result = []
-
-        lib_doc = namespace.get_library_doc()
-        for doc in self.parent.documents.documents:
-            if doc.language_id != "robotframework":
-                continue
-
-            doc_namespace = self.parent.documents_cache.get_only_initialized_namespace(doc)
-            if doc_namespace is None:
-                continue
-
-            if doc_namespace.is_analyzed():
-                for ref in doc_namespace.get_namespace_references():
-                    if ref.library_doc == lib_doc:
-                        result.append(doc)
-
-        return result
-
-    def modify_diagnostics(self, document: TextDocument, diagnostics: List[Diagnostic]) -> List[Diagnostic]:
-        return self.parent.documents_cache.get_diagnostic_modifier(document).modify_diagnostics(diagnostics)
+    def modify_diagnostics(
+        self, document: TextDocument, diagnostics: List[Diagnostic]
+    ) -> List[Diagnostic]:
+        return self.parent.documents_cache.get_diagnostic_modifier(
+            document
+        ).modify_diagnostics(diagnostics)
 
     @language_id("robotframework")
     def collect_namespace_diagnostics(
-        self, sender: Any, document: TextDocument, diagnostics_type: DiagnosticsCollectType
+        self,
+        sender: Any,
+        document: TextDocument,
+        diagnostics_type: DiagnosticsCollectType,
     ) -> DiagnosticsResult:
         try:
             namespace = self.parent.documents_cache.get_namespace(document)
 
             return DiagnosticsResult(
-                self.collect_namespace_diagnostics, self.modify_diagnostics(document, namespace.get_diagnostics())
+                self.collect_namespace_diagnostics,
+                self.modify_diagnostics(document, namespace.get_diagnostics()),
             )
         except (CancelledError, SystemExit, KeyboardInterrupt):
             raise
@@ -141,7 +141,10 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
     @language_id("robotframework")
     @_logger.call
     def collect_unused_keyword_references(
-        self, sender: Any, document: TextDocument, diagnostics_type: DiagnosticsCollectType
+        self,
+        sender: Any,
+        document: TextDocument,
+        diagnostics_type: DiagnosticsCollectType,
     ) -> DiagnosticsResult:
         config = self.parent.workspace.get_configuration(AnalysisConfig, document.uri)
 
@@ -153,7 +156,9 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
 
         return self._collect_unused_keyword_references(document)
 
-    def _collect_unused_keyword_references(self, document: TextDocument) -> DiagnosticsResult:
+    def _collect_unused_keyword_references(
+        self, document: TextDocument
+    ) -> DiagnosticsResult:
         try:
             namespace = self.parent.documents_cache.get_namespace(document)
 
@@ -161,7 +166,9 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
             for kw in (namespace.get_library_doc()).keywords.values():
                 check_current_task_canceled()
 
-                references = self.parent.robot_references.find_keyword_references(document, kw, False, True)
+                references = self.parent.robot_references.find_keyword_references(
+                    document, kw, False, True
+                )
                 if not references:
                     result.append(
                         Diagnostic(
@@ -174,7 +181,10 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
                         )
                     )
 
-            return DiagnosticsResult(self.collect_unused_keyword_references, self.modify_diagnostics(document, result))
+            return DiagnosticsResult(
+                self.collect_unused_keyword_references,
+                self.modify_diagnostics(document, result),
+            )
         except (CancelledError, SystemExit, KeyboardInterrupt):
             raise
         except BaseException as e:
@@ -200,7 +210,10 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
     @language_id("robotframework")
     @_logger.call
     def collect_unused_variable_references(
-        self, sender: Any, document: TextDocument, diagnostics_type: DiagnosticsCollectType
+        self,
+        sender: Any,
+        document: TextDocument,
+        diagnostics_type: DiagnosticsCollectType,
     ) -> DiagnosticsResult:
         config = self.parent.workspace.get_configuration(AnalysisConfig, document.uri)
 
@@ -208,11 +221,15 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
             return DiagnosticsResult(self.collect_unused_variable_references, [])
 
         if diagnostics_type != DiagnosticsCollectType.SLOW:
-            return DiagnosticsResult(self.collect_unused_variable_references, None, True)
+            return DiagnosticsResult(
+                self.collect_unused_variable_references, None, True
+            )
 
         return self._collect_unused_variable_references(document)
 
-    def _collect_unused_variable_references(self, document: TextDocument) -> DiagnosticsResult:
+    def _collect_unused_variable_references(
+        self, document: TextDocument
+    ) -> DiagnosticsResult:
         try:
             namespace = self.parent.documents_cache.get_namespace(document)
 
@@ -222,14 +239,25 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
                 check_current_task_canceled()
 
                 if isinstance(
-                    var, (LibraryArgumentDefinition, EnvironmentVariableDefinition, GlobalVariableDefinition)
+                    var,
+                    (
+                        LibraryArgumentDefinition,
+                        EnvironmentVariableDefinition,
+                        GlobalVariableDefinition,
+                    ),
                 ):
                     continue
 
-                if var.name_token is not None and var.name_token.value and var.name_token.value.startswith("_"):
+                if (
+                    var.name_token is not None
+                    and var.name_token.value
+                    and var.name_token.value.startswith("_")
+                ):
                     continue
 
-                references = self.parent.robot_references.find_variable_references(document, var, False, True)
+                references = self.parent.robot_references.find_variable_references(
+                    document, var, False, True
+                )
                 if not references:
                     result.append(
                         Diagnostic(
@@ -243,7 +271,10 @@ class RobotDiagnosticsProtocolPart(RobotLanguageServerProtocolPart):
                         )
                     )
 
-            return DiagnosticsResult(self.collect_unused_variable_references, self.modify_diagnostics(document, result))
+            return DiagnosticsResult(
+                self.collect_unused_variable_references,
+                self.modify_diagnostics(document, result),
+            )
         except (CancelledError, SystemExit, KeyboardInterrupt):
             raise
         except BaseException as e:

--- a/packages/robot/src/robotcode/robot/diagnostics/document_cache_helper.py
+++ b/packages/robot/src/robotcode/robot/diagnostics/document_cache_helper.py
@@ -824,7 +824,11 @@ class DocumentsCacheHelper:
         )
 
         if result is not None:
-            self._logger.debug(lambda: f"Loaded namespace from cache for {source}", context_name="import")
+            self._logger.debug(
+                lambda: f"Loaded namespace from cache for {source} "
+                f"(fully_analyzed={cache_data.fully_analyzed}, _analyzed={result._analyzed})",
+                context_name="import",
+            )
 
         return result
 
@@ -852,7 +856,10 @@ class DocumentsCacheHelper:
         # Save as single tuple (meta, spec) - atomic and consistent
         try:
             imports_manager.data_cache.save_cache_data(CacheSection.NAMESPACE, cache_file, (meta, cache_data))
-            self._logger.debug(lambda: f"Saved namespace to cache for {namespace.source}", context_name="import")
+            self._logger.debug(
+                lambda: f"Saved namespace to cache for {namespace.source} (fully_analyzed={cache_data.fully_analyzed})",
+                context_name="import",
+            )
         except OSError:
             self._logger.debug(lambda: f"Failed to save namespace cache for {namespace.source}", context_name="import")
 

--- a/packages/robot/src/robotcode/robot/diagnostics/document_cache_helper.py
+++ b/packages/robot/src/robotcode/robot/diagnostics/document_cache_helper.py
@@ -105,12 +105,12 @@ class DocumentsCacheHelper:
         self._ref_tracking_lock = threading.RLock()
         self._keyword_ref_users: dict[tuple[str, str], weakref.WeakSet[TextDocument]] = {}
         self._variable_ref_users: dict[tuple[str, str], weakref.WeakSet[TextDocument]] = {}
-        self._doc_keyword_refs: weakref.WeakKeyDictionary[
-            TextDocument, set[tuple[str, str]]
-        ] = weakref.WeakKeyDictionary()
-        self._doc_variable_refs: weakref.WeakKeyDictionary[
-            TextDocument, set[tuple[str, str]]
-        ] = weakref.WeakKeyDictionary()
+        self._doc_keyword_refs: weakref.WeakKeyDictionary[TextDocument, set[tuple[str, str]]] = (
+            weakref.WeakKeyDictionary()
+        )
+        self._doc_variable_refs: weakref.WeakKeyDictionary[TextDocument, set[tuple[str, str]]] = (
+            weakref.WeakKeyDictionary()
+        )
 
         # Counter for periodic cleanup of stale dependency map entries
         self._track_count = 0
@@ -760,9 +760,7 @@ class DocumentsCacheHelper:
                 return None
 
             if saved_meta.content_hash != current_hash:
-                self._logger.debug(
-                    lambda: f"Namespace cache content hash mismatch for {source}", context_name="import"
-                )
+                self._logger.debug(lambda: f"Namespace cache content hash mismatch for {source}", context_name="import")
                 return None
 
         # Validate environment identity (detects venv changes, PYTHONPATH changes, etc.)
@@ -853,9 +851,7 @@ class DocumentsCacheHelper:
 
         # Save as single tuple (meta, spec) - atomic and consistent
         try:
-            imports_manager.data_cache.save_cache_data(
-                CacheSection.NAMESPACE, cache_file, (meta, cache_data)
-            )
+            imports_manager.data_cache.save_cache_data(CacheSection.NAMESPACE, cache_file, (meta, cache_data))
             self._logger.debug(lambda: f"Saved namespace to cache for {namespace.source}", context_name="import")
         except OSError:
             self._logger.debug(lambda: f"Failed to save namespace cache for {namespace.source}", context_name="import")

--- a/packages/robot/src/robotcode/robot/diagnostics/document_cache_helper.py
+++ b/packages/robot/src/robotcode/robot/diagnostics/document_cache_helper.py
@@ -887,6 +887,10 @@ class DocumentsCacheHelper:
             # Mark as initialized in document data and track imports
             document.set_data(self.INITIALIZED_NAMESPACE, cached)
             self._track_imports(document, cached)
+            # If fully analyzed from cache, also track references
+            # (since has_analysed event won't fire for already-analyzed namespaces)
+            if cached._analyzed:
+                self._track_references(document, cached)
             return cached
 
         # Cache miss - create new namespace

--- a/packages/robot/src/robotcode/robot/diagnostics/imports_manager.py
+++ b/packages/robot/src/robotcode/robot/diagnostics/imports_manager.py
@@ -1246,10 +1246,7 @@ class ImportsManager:
             if self._executor is None:
                 # Cap at 4 workers to balance parallelism with memory usage
                 max_workers = min(mp.cpu_count() or 1, 4)
-                self._executor = ProcessPoolExecutor(
-                    max_workers=max_workers,
-                    mp_context=mp.get_context("spawn")
-                )
+                self._executor = ProcessPoolExecutor(max_workers=max_workers, mp_context=mp.get_context("spawn"))
 
         return self._executor
 
@@ -1440,9 +1437,7 @@ class ImportsManager:
                     saved_meta = self.data_cache.read_cache_data(CacheSection.RESOURCE, meta_file, ResourceMetaData)
                     if saved_meta == meta:
                         spec_path = meta.filepath_base + ".spec"
-                        self._logger.debug(
-                            lambda: f"Use cached resource data for {source}", context_name="import"
-                        )
+                        self._logger.debug(lambda: f"Use cached resource data for {source}", context_name="import")
                         result = self.data_cache.read_cache_data(CacheSection.RESOURCE, spec_path, LibraryDoc)
                         # Store in in-memory cache too
                         if entry is None:
@@ -1476,9 +1471,7 @@ class ImportsManager:
 
         return result
 
-    def get_libdoc_for_source(
-        self, source: Optional[str], name: Optional[str] = None
-    ) -> Optional[LibraryDoc]:
+    def get_libdoc_for_source(self, source: Optional[str], name: Optional[str] = None) -> Optional[LibraryDoc]:
         """Look up a library LibraryDoc by its source path from disk cache.
 
         Used when restoring namespace from cache - looks up cached library data.

--- a/packages/robot/src/robotcode/robot/diagnostics/library_doc.py
+++ b/packages/robot/src/robotcode/robot/diagnostics/library_doc.py
@@ -620,9 +620,7 @@ class KeywordDoc(SourceEntity):
     name_token: Optional[Token] = field(default=None, compare=False)
     arguments: List[ArgumentInfo] = field(default_factory=list, compare=False)
     arguments_spec: Optional[ArgumentSpec] = field(default=None, compare=False)
-    argument_definitions: Optional[List[ArgumentDefinition]] = field(
-        default=None, compare=False, metadata={"nosave": True}
-    )
+    argument_definitions: Optional[List[ArgumentDefinition]] = field(default=None, compare=False)
     doc: str = field(default="", compare=False)
     tags: List[str] = field(default_factory=list)
     type: str = "keyword"

--- a/packages/robot/src/robotcode/robot/diagnostics/namespace.py
+++ b/packages/robot/src/robotcode/robot/diagnostics/namespace.py
@@ -1276,38 +1276,42 @@ class Namespace:
         # Convert LibraryEntry -> CachedLibraryEntry
         cached_libraries: list[tuple[str, CachedLibraryEntry]] = []
         for key, entry in self._libraries.items():
-            cached_libraries.append((
-                key,
-                CachedLibraryEntry(
-                    name=entry.name,
-                    import_name=entry.import_name,
-                    library_doc_source=entry.library_doc.source,
-                    args=entry.args,
-                    alias=entry.alias,
-                    import_range=entry.import_range,
-                    import_source=entry.import_source,
-                    alias_range=entry.alias_range,
-                ),
-            ))
+            cached_libraries.append(
+                (
+                    key,
+                    CachedLibraryEntry(
+                        name=entry.name,
+                        import_name=entry.import_name,
+                        library_doc_source=entry.library_doc.source,
+                        args=entry.args,
+                        alias=entry.alias,
+                        import_range=entry.import_range,
+                        import_source=entry.import_source,
+                        alias_range=entry.alias_range,
+                    ),
+                )
+            )
 
         # Convert ResourceEntry -> CachedResourceEntry
         cached_resources: list[tuple[str, CachedResourceEntry]] = []
         for key, entry in self._resources.items():
-            cached_resources.append((
-                key,
-                CachedResourceEntry(
-                    name=entry.name,
-                    import_name=entry.import_name,
-                    library_doc_source=entry.library_doc.source,
-                    args=entry.args,
-                    alias=entry.alias,
-                    import_range=entry.import_range,
-                    import_source=entry.import_source,
-                    alias_range=entry.alias_range,
-                    imports=tuple(entry.imports),
-                    variables=tuple(entry.variables),
-                ),
-            ))
+            cached_resources.append(
+                (
+                    key,
+                    CachedResourceEntry(
+                        name=entry.name,
+                        import_name=entry.import_name,
+                        library_doc_source=entry.library_doc.source,
+                        args=entry.args,
+                        alias=entry.alias,
+                        import_range=entry.import_range,
+                        import_source=entry.import_source,
+                        alias_range=entry.alias_range,
+                        imports=tuple(entry.imports),
+                        variables=tuple(entry.variables),
+                    ),
+                )
+            )
 
         # Build resources_files mapping (source -> key)
         resources_files: list[tuple[str, str]] = []
@@ -1321,20 +1325,22 @@ class Namespace:
         # Convert VariablesEntry -> CachedVariablesEntry
         cached_variables: list[tuple[str, CachedVariablesEntry]] = []
         for key, entry in self._variables_imports.items():
-            cached_variables.append((
-                key,
-                CachedVariablesEntry(
-                    name=entry.name,
-                    import_name=entry.import_name,
-                    library_doc_source=entry.library_doc.source,
-                    args=entry.args,
-                    alias=entry.alias,
-                    import_range=entry.import_range,
-                    import_source=entry.import_source,
-                    alias_range=entry.alias_range,
-                    variables=tuple(entry.variables),
-                ),
-            ))
+            cached_variables.append(
+                (
+                    key,
+                    CachedVariablesEntry(
+                        name=entry.name,
+                        import_name=entry.import_name,
+                        library_doc_source=entry.library_doc.source,
+                        args=entry.args,
+                        alias=entry.alias,
+                        import_range=entry.import_range,
+                        import_source=entry.import_source,
+                        alias_range=entry.alias_range,
+                        variables=tuple(entry.variables),
+                    ),
+                )
+            )
 
         return NamespaceCacheData(
             libraries=tuple(cached_libraries),
@@ -1368,9 +1374,7 @@ class Namespace:
     ) -> bool:
         """Restore library entries from cache. Returns False if cache is stale."""
         for key, cached_entry in cached_libraries:
-            library_doc = imports_manager.get_libdoc_for_source(
-                cached_entry.library_doc_source, cached_entry.name
-            )
+            library_doc = imports_manager.get_libdoc_for_source(cached_entry.library_doc_source, cached_entry.name)
             if library_doc is None:
                 return False
             ns._libraries[key] = LibraryEntry(
@@ -1640,25 +1644,19 @@ class Namespace:
         # Include own variables
         if ns._own_variables is not None:
             for var in ns._own_variables:
-                key = VariableRefKey(
-                    var.source or "", var.name, var.type.value, var.line_no, var.col_offset
-                )
+                key = VariableRefKey(var.source or "", var.name, var.type.value, var.line_no, var.col_offset)
                 lookup[key] = var
 
         # Include variables from imported resources
         for res_entry in ns._resources.values():
             for var in res_entry.variables:
-                key = VariableRefKey(
-                    var.source or "", var.name, var.type.value, var.line_no, var.col_offset
-                )
+                key = VariableRefKey(var.source or "", var.name, var.type.value, var.line_no, var.col_offset)
                 lookup[key] = var
 
         # Include variables from variables imports
         for var_entry in ns._variables_imports.values():
             for var in var_entry.variables:
-                key = VariableRefKey(
-                    var.source or "", var.name, var.type.value, var.line_no, var.col_offset
-                )
+                key = VariableRefKey(var.source or "", var.name, var.type.value, var.line_no, var.col_offset)
                 lookup[key] = var
 
         # Restore references with validation
@@ -1697,17 +1695,13 @@ class Namespace:
 
         if ns._own_variables is not None:
             for var in ns._own_variables:
-                key = VariableRefKey(
-                    var.source or "", var.name, var.type.value, var.line_no, var.col_offset
-                )
+                key = VariableRefKey(var.source or "", var.name, var.type.value, var.line_no, var.col_offset)
                 lookup[key] = var
 
         # Also check resources for local variables defined there
         for res_entry in ns._resources.values():
             for var in res_entry.variables:
-                key = VariableRefKey(
-                    var.source or "", var.name, var.type.value, var.line_no, var.col_offset
-                )
+                key = VariableRefKey(var.source or "", var.name, var.type.value, var.line_no, var.col_offset)
                 lookup[key] = var
 
         # Restore assignments with validation

--- a/packages/robot/src/robotcode/robot/diagnostics/namespace.py
+++ b/packages/robot/src/robotcode/robot/diagnostics/namespace.py
@@ -204,6 +204,7 @@ class VariableRefKey:
     - source + line_no + col_offset uniquely identifies a location
     - name ensures we match the right variable at that location
     - var_type distinguishes between different variable definition types
+    - end_col_offset allows accurate range restoration
     """
 
     source: str  # File path
@@ -211,6 +212,7 @@ class VariableRefKey:
     var_type: str  # VariableDefinitionType.value
     line_no: int
     col_offset: int
+    end_col_offset: int = 0  # Default 0 for backward compatibility
 
 
 @dataclass(frozen=True)
@@ -1047,6 +1049,7 @@ class Namespace:
             var.type.value,
             var.line_no,
             var.col_offset,
+            var.end_col_offset,
         )
 
     @property
@@ -1851,12 +1854,27 @@ class Namespace:
 
         Note: Library arguments have col_offset=-1 (sentinel value for "no position").
         These should NOT be adjusted - return them as-is.
+
+        Note: In RF 7.3+, arg_def.name may include type annotations (e.g., "${timeout: int}"),
+        but the analyzer normalizes names (e.g., "${timeout}"). We must use the NORMALIZED
+        name length for position calculations to match what the analyzer stored.
         """
         # Library arguments have col_offset=-1 (no position info) - don't adjust
         if arg_def.col_offset < 0:
             return arg_def, cls._make_variable_ref_key(arg_def)
 
-        var_name_len = cls._get_variable_name_length(arg_def.name)
+        # Use normalized name for length calculation (RF 7.3+ may have type annotations)
+        # _make_variable_ref_key normalizes names, so we need to match that behavior
+        normalized_name = arg_def.name
+        if arg_def.name and arg_def.name.startswith(("${", "@{", "&{", "%{")):
+            try:
+                matcher = VariableMatcher(arg_def.name, parse_type=True, ignore_errors=True)
+                if matcher.name:
+                    normalized_name = matcher.name
+            except Exception:
+                pass
+
+        var_name_len = cls._get_variable_name_length(normalized_name)
         stripped_col = arg_def.col_offset + _VAR_PREFIX_LEN
         stripped_end = stripped_col + var_name_len
 
@@ -1921,26 +1939,38 @@ class Namespace:
                 if matcher.base is None:
                     continue
 
-                # Extract name (without pattern/type for embedded args with patterns)
+                # Extract name, type, and pattern (matching namespace_analyzer.py logic)
+                type_annotation = None
+                pattern = None
+
                 if ":" not in matcher.base:
                     name = matcher.base
+                elif get_robot_version() >= (7, 3):
+                    # RF 7.3+ format: ${name: type: pattern} or ${name: type}
+                    re_match = NamespaceAnalyzer.EMBEDDED_ARGUMENTS_MATCHER.fullmatch(matcher.base)
+                    if re_match:
+                        name, type_annotation, _, pattern = re_match.groups()
+                    else:
+                        # Fallback: ${name:pattern} format
+                        name, pattern = matcher.base.split(":", 1)
                 else:
-                    # Handle ${name:pattern} or ${name: type: pattern} (RF 7.3+)
-                    name = matcher.base.split(":")[0]
+                    # Pre-7.3: ${name:pattern} format only
+                    name, pattern = matcher.base.split(":", 1)
 
                 full_name = f"{matcher.identifier}{{{name}}}"
-                # Use stripped positions (pointing to variable name, not $)
-                # This matches how references are found during live analysis
-                stripped_col = variable_token.col_offset + _VAR_PREFIX_LEN
+                # Use ORIGINAL positions (pointing to '$' in '${arg}') to match
+                # what namespace_analyzer.py does in visit_KeywordName
                 arg_def = EmbeddedArgumentDefinition(
                     name=full_name,
                     name_token=None,
                     line_no=variable_token.lineno,
-                    col_offset=stripped_col,
+                    col_offset=variable_token.col_offset,
                     end_line_no=variable_token.lineno,
-                    end_col_offset=stripped_col + len(name),
+                    end_col_offset=variable_token.end_col_offset,
                     source=kw_doc.source,
                     keyword_doc=kw_doc,
+                    value_type=type_annotation,
+                    pattern=pattern,
                 )
                 key = cls._make_variable_ref_key(arg_def)
                 if key not in lookup:
@@ -1955,13 +1985,22 @@ class Namespace:
 
         Used to recreate local variables from cache keys when the original
         VariableDefinition is not available (e.g., for ${result}= assignments).
+
+        Uses end_col_offset from the key if available (non-zero), otherwise
+        falls back to calculating from name length for backward compatibility.
         """
-        var_name_len = cls._get_variable_name_length(key.name)
+        if key.end_col_offset > 0:
+            end_col = key.end_col_offset
+        else:
+            # Fallback for old cache entries without end_col_offset
+            var_name_len = cls._get_variable_name_length(key.name)
+            end_col = key.col_offset + var_name_len
+
         return VariableDefinition(
             line_no=key.line_no,
             col_offset=key.col_offset,
             end_line_no=key.line_no,
-            end_col_offset=key.col_offset + var_name_len,
+            end_col_offset=end_col,
             source=key.source or None,
             name=key.name,
             name_token=None,

--- a/packages/robot/src/robotcode/robot/diagnostics/namespace_analyzer.py
+++ b/packages/robot/src/robotcode/robot/diagnostics/namespace_analyzer.py
@@ -1367,6 +1367,7 @@ class NamespaceAnalyzer(Visitor):
                     )
                     self._variables[var_def.matcher] = var_def
                     self._variable_references[var_def] = set()
+                    self._local_variable_assignments[var_def].add(var_def.range)
                 else:
                     if existing_var.type in [
                         VariableDefinitionType.ARGUMENT,
@@ -1403,7 +1404,7 @@ class NamespaceAnalyzer(Visitor):
                     )
                     is None
                 ):
-                    self._variables[matcher] = LocalVariableDefinition(
+                    var_def = LocalVariableDefinition(
                         name=variable_token.value,
                         name_token=strip_variable_token(variable_token),
                         line_no=variable_token.lineno,
@@ -1412,6 +1413,9 @@ class NamespaceAnalyzer(Visitor):
                         end_col_offset=variable_token.end_col_offset,
                         source=self._namespace.source,
                     )
+                    self._variables[matcher] = var_def
+                    self._variable_references[var_def] = set()
+                    self._local_variable_assignments[var_def].add(var_def.range)
 
             except (VariableError, InvalidVariableError):
                 pass

--- a/tests/robotcode/language_server/robotframework/parts/test_namespace_caching.py
+++ b/tests/robotcode/language_server/robotframework/parts/test_namespace_caching.py
@@ -1,0 +1,222 @@
+"""Integration tests for namespace caching functionality."""
+
+import pickle
+from pathlib import Path
+
+import pytest
+
+from robotcode.language_server.robotframework.protocol import (
+    RobotLanguageServerProtocol,
+)
+
+# Cache directory relative to the test data root
+DATA_ROOT = Path(__file__).parent / "data"
+CACHE_DIR = DATA_ROOT / ".robotcode_cache"
+
+
+class TestNamespaceCaching:
+    """Integration tests for namespace cache behavior."""
+
+    def test_cache_directory_created_after_analysis(
+        self,
+        protocol: RobotLanguageServerProtocol,
+    ) -> None:
+        """Cache directory is created after workspace analysis."""
+        # The protocol fixture already runs workspace diagnostics
+        # which should create the cache directory
+        assert CACHE_DIR.exists(), "Cache directory should be created"
+
+    def test_namespace_cache_files_created(
+        self,
+        protocol: RobotLanguageServerProtocol,
+    ) -> None:
+        """Namespace cache files are created for analyzed robot files."""
+        # Look for namespace cache files
+        ns_cache_dirs = list(CACHE_DIR.glob("*/*/namespace"))
+
+        assert len(ns_cache_dirs) > 0, "Should have namespace cache directories"
+
+        # Check for cache files (either .cache.pkl single-file or legacy .meta.pkl/.spec.pkl)
+        cache_files: list[Path] = []
+        for ns_dir in ns_cache_dirs:
+            cache_files.extend(ns_dir.glob("*.cache.pkl"))
+            cache_files.extend(ns_dir.glob("*.meta.pkl"))
+
+        assert len(cache_files) > 0, "Should have namespace cache files"
+
+    def test_cache_file_contains_valid_data(
+        self,
+        protocol: RobotLanguageServerProtocol,
+    ) -> None:
+        """Cache files contain valid pickled metadata and spec data."""
+        ns_cache_dirs = list(CACHE_DIR.glob("*/*/namespace"))
+        if not ns_cache_dirs:
+            pytest.skip("No namespace cache directory found")
+
+        # Find a cache file
+        cache_files = list(ns_cache_dirs[0].glob("*.cache.pkl"))
+        if not cache_files:
+            pytest.skip("No cache files found")
+
+        # Verify it's valid pickle with expected structure
+        with open(cache_files[0], "rb") as f:
+            data = pickle.load(f)
+
+        # Single-file format stores (meta, spec) tuple
+        assert isinstance(data, tuple), "Cache should be a tuple"
+        assert len(data) == 2, "Cache should have (meta, spec)"
+
+        meta, _spec = data
+        # Verify metadata has required fields
+        assert hasattr(meta, "source"), "Meta should have source"
+        assert hasattr(meta, "mtime"), "Meta should have mtime"
+        assert hasattr(meta, "content_hash"), "Meta should have content_hash"
+
+    def test_cache_metadata_tracks_environment(
+        self,
+        protocol: RobotLanguageServerProtocol,
+    ) -> None:
+        """Cache metadata includes Python environment tracking fields."""
+        ns_cache_dirs = list(CACHE_DIR.glob("*/*/namespace"))
+        if not ns_cache_dirs:
+            pytest.skip("No namespace cache directory found")
+
+        cache_files = list(ns_cache_dirs[0].glob("*.cache.pkl"))
+        if not cache_files:
+            pytest.skip("No cache files found")
+
+        with open(cache_files[0], "rb") as f:
+            meta, _spec = pickle.load(f)
+
+        # Environment tracking fields (for detecting venv changes)
+        assert hasattr(meta, "python_executable"), "Should track python_executable"
+        assert hasattr(meta, "sys_path_hash"), "Should track sys_path_hash"
+        assert hasattr(meta, "robot_version"), "Should track robot_version"
+
+    def test_corrupt_cache_does_not_crash(
+        self,
+        protocol: RobotLanguageServerProtocol,
+    ) -> None:
+        """Corrupted cache files are handled gracefully without crashing."""
+        ns_cache_dirs = list(CACHE_DIR.glob("*/*/namespace"))
+        if not ns_cache_dirs:
+            pytest.skip("No namespace cache directory found")
+
+        # Create a corrupt cache file
+        corrupt_file = ns_cache_dirs[0] / "corrupt_test.cache.pkl"
+        corrupt_file.write_bytes(b"NOT VALID PICKLE DATA")
+
+        try:
+            # Access a document - should not crash despite corrupt cache
+            test_file = DATA_ROOT / "tests" / "hover.robot"
+            if test_file.exists():
+                doc = protocol.documents.get_or_open_document(test_file, "robotframework")
+                # Try to get namespace (triggers cache lookup)
+                ns = protocol.documents_cache.get_namespace(doc)
+                assert ns is not None, "Should get namespace despite corrupt sibling cache"
+        finally:
+            # Cleanup
+            if corrupt_file.exists():
+                corrupt_file.unlink()
+
+    def test_different_files_have_different_cache_keys(
+        self,
+        protocol: RobotLanguageServerProtocol,
+    ) -> None:
+        """Files in different directories have unique cache keys (no collisions)."""
+        ns_cache_dirs = list(CACHE_DIR.glob("*/*/namespace"))
+        if not ns_cache_dirs:
+            pytest.skip("No namespace cache directory found")
+
+        # Collect all cache file names
+        cache_files: list[Path] = []
+        for ns_dir in ns_cache_dirs:
+            cache_files.extend(ns_dir.glob("*.cache.pkl"))
+
+        if len(cache_files) < 2:
+            pytest.skip("Need at least 2 cache files to test uniqueness")
+
+        # All cache file names should be unique
+        names = [f.name for f in cache_files]
+        assert len(names) == len(set(names)), "Cache file names should be unique"
+
+
+class TestCacheInvalidation:
+    """Tests for cache invalidation behavior."""
+
+    def test_namespace_available_for_document(
+        self,
+        protocol: RobotLanguageServerProtocol,
+    ) -> None:
+        """Namespace is available for documents after analysis."""
+        test_file = DATA_ROOT / "tests" / "hover.robot"
+        if not test_file.exists():
+            pytest.skip("Test file not found")
+
+        doc = protocol.documents.get_or_open_document(test_file, "robotframework")
+        ns = protocol.documents_cache.get_namespace(doc)
+
+        assert ns is not None, "Should have namespace for document"
+        assert ns.source is not None, "Namespace should have source"
+
+    def test_namespace_has_source_and_imports(
+        self,
+        protocol: RobotLanguageServerProtocol,
+    ) -> None:
+        """Namespace contains source path and import information."""
+        test_file = DATA_ROOT / "tests" / "hover.robot"
+        if not test_file.exists():
+            pytest.skip("Test file not found")
+
+        doc = protocol.documents.get_or_open_document(test_file, "robotframework")
+        ns = protocol.documents_cache.get_namespace(doc)
+
+        assert ns is not None
+        assert ns.source is not None, "Namespace should have source path"
+        # Namespace should have libraries (at least BuiltIn is implicit)
+        assert hasattr(ns, "get_libraries"), "Namespace should support get_libraries"
+
+
+class TestLibraryDocCaching:
+    """Tests for library documentation caching."""
+
+    def test_libdoc_cache_directory_exists(
+        self,
+        protocol: RobotLanguageServerProtocol,
+    ) -> None:
+        """Library documentation cache directory is created."""
+        libdoc_dirs = list(CACHE_DIR.glob("*/*/libdoc"))
+
+        # After analyzing files that import libraries, should have libdoc cache
+        assert len(libdoc_dirs) > 0, "Should have libdoc cache directories"
+
+    def test_libdoc_cache_files_exist(
+        self,
+        protocol: RobotLanguageServerProtocol,
+    ) -> None:
+        """Library documentation cache contains pickle files."""
+        libdoc_dirs = list(CACHE_DIR.glob("*/*/libdoc"))
+        if not libdoc_dirs:
+            pytest.skip("No libdoc cache directory found")
+
+        cache_files: list[Path] = []
+        for libdoc_dir in libdoc_dirs:
+            cache_files.extend(libdoc_dir.glob("*.pkl"))
+
+        assert len(cache_files) > 0, "Should have libdoc cache files"
+
+    def test_builtin_library_is_cached(
+        self,
+        protocol: RobotLanguageServerProtocol,
+    ) -> None:
+        """BuiltIn library documentation is cached."""
+        libdoc_dirs = list(CACHE_DIR.glob("*/*/libdoc"))
+        if not libdoc_dirs:
+            pytest.skip("No libdoc cache directory found")
+
+        # Look for BuiltIn library cache (may be in subdirectory like robot/libraries/)
+        builtin_files: list[Path] = []
+        for libdoc_dir in libdoc_dirs:
+            builtin_files.extend(libdoc_dir.glob("**/*BuiltIn*"))
+
+        assert len(builtin_files) > 0, "BuiltIn library should be cached"

--- a/tests/robotcode/robot/diagnostics/test_data_cache.py
+++ b/tests/robotcode/robot/diagnostics/test_data_cache.py
@@ -1,0 +1,257 @@
+"""Unit tests for data_cache.py - cache implementations."""
+
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from robotcode.robot.diagnostics.data_cache import (
+    CacheSection,
+    JsonDataCache,
+    PickleDataCache,
+)
+
+
+@dataclass
+class SampleData:
+    """Sample dataclass for testing serialization."""
+
+    name: str
+    value: int
+
+
+class TestCacheSection:
+    """Tests for CacheSection enum."""
+
+    def test_cache_section_values(self) -> None:
+        """Verify CacheSection enum has expected values."""
+        assert CacheSection.LIBRARY.value == "libdoc"
+        assert CacheSection.VARIABLES.value == "variables"
+        assert CacheSection.RESOURCE.value == "resource"
+        assert CacheSection.NAMESPACE.value == "namespace"
+
+
+class TestPickleDataCache:
+    """Tests for PickleDataCache implementation."""
+
+    def test_init_creates_cache_directory(self, tmp_path: Path) -> None:
+        """Cache directory is created on initialization."""
+        cache_dir = tmp_path / "cache"
+        assert not cache_dir.exists()
+
+        PickleDataCache(cache_dir)
+
+        assert cache_dir.exists()
+        assert (cache_dir / ".gitignore").exists()
+
+    def test_init_with_existing_directory(self, tmp_path: Path) -> None:
+        """Initialization works with existing directory."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir(parents=True)
+
+        cache = PickleDataCache(cache_dir)
+
+        assert cache.cache_dir == cache_dir
+
+    def test_build_cache_data_filename(self, tmp_path: Path) -> None:
+        """Filename is built correctly with section and entry name."""
+        cache = PickleDataCache(tmp_path)
+
+        path = cache.build_cache_data_filename(CacheSection.LIBRARY, "test_entry")
+
+        assert path == tmp_path / "libdoc" / "test_entry.pkl"
+
+    def test_cache_data_exists_returns_false_for_missing(self, tmp_path: Path) -> None:
+        """cache_data_exists returns False when file doesn't exist."""
+        cache = PickleDataCache(tmp_path)
+
+        assert cache.cache_data_exists(CacheSection.LIBRARY, "nonexistent") is False
+
+    def test_cache_data_exists_returns_true_for_existing(self, tmp_path: Path) -> None:
+        """cache_data_exists returns True when file exists."""
+        cache = PickleDataCache(tmp_path)
+        cache.save_cache_data(CacheSection.LIBRARY, "test", {"key": "value"})
+
+        assert cache.cache_data_exists(CacheSection.LIBRARY, "test") is True
+
+    def test_save_and_read_cache_data_dict(self, tmp_path: Path) -> None:
+        """Save and read dictionary data correctly."""
+        cache = PickleDataCache(tmp_path)
+        data = {"name": "test", "values": [1, 2, 3]}
+
+        cache.save_cache_data(CacheSection.LIBRARY, "test", data)
+        result = cache.read_cache_data(CacheSection.LIBRARY, "test", dict)
+
+        assert result == data
+
+    def test_save_and_read_cache_data_dataclass(self, tmp_path: Path) -> None:
+        """Save and read dataclass correctly."""
+        cache = PickleDataCache(tmp_path)
+        data = SampleData(name="test", value=42)
+
+        cache.save_cache_data(CacheSection.NAMESPACE, "sample", data)
+        result = cache.read_cache_data(CacheSection.NAMESPACE, "sample", SampleData)
+
+        assert result == data
+
+    def test_read_cache_data_type_mismatch_raises_typeerror(self, tmp_path: Path) -> None:
+        """TypeError is raised when cached data doesn't match expected type."""
+        cache = PickleDataCache(tmp_path)
+        cache.save_cache_data(CacheSection.LIBRARY, "test", {"key": "value"})
+
+        with pytest.raises(TypeError, match=r"Expected.*str.*got.*dict"):
+            cache.read_cache_data(CacheSection.LIBRARY, "test", str)
+
+    def test_read_cache_data_accepts_tuple_of_types(self, tmp_path: Path) -> None:
+        """read_cache_data accepts a tuple of types for validation."""
+        cache = PickleDataCache(tmp_path)
+        cache.save_cache_data(CacheSection.LIBRARY, "test", {"key": "value"})
+
+        result = cache.read_cache_data(CacheSection.LIBRARY, "test", (dict, list))
+
+        assert result == {"key": "value"}
+
+    def test_read_cache_data_missing_file_raises_error(self, tmp_path: Path) -> None:
+        """FileNotFoundError is raised when cache file doesn't exist."""
+        cache = PickleDataCache(tmp_path)
+
+        with pytest.raises(FileNotFoundError):
+            cache.read_cache_data(CacheSection.LIBRARY, "nonexistent", dict)
+
+    def test_save_creates_section_directory(self, tmp_path: Path) -> None:
+        """Section subdirectory is created when saving."""
+        cache = PickleDataCache(tmp_path)
+
+        cache.save_cache_data(CacheSection.VARIABLES, "test", {"data": 1})
+
+        assert (tmp_path / "variables").is_dir()
+
+    def test_save_overwrites_existing_file(self, tmp_path: Path) -> None:
+        """Existing cache file is overwritten on save."""
+        cache = PickleDataCache(tmp_path)
+        cache.save_cache_data(CacheSection.LIBRARY, "test", {"version": 1})
+        cache.save_cache_data(CacheSection.LIBRARY, "test", {"version": 2})
+
+        result = cache.read_cache_data(CacheSection.LIBRARY, "test", dict)
+
+        assert result == {"version": 2}
+
+    def test_atomic_write_no_temp_files_left(self, tmp_path: Path) -> None:
+        """No temporary files are left after successful save."""
+        cache = PickleDataCache(tmp_path)
+        cache.save_cache_data(CacheSection.LIBRARY, "test", {"data": 1})
+
+        section_dir = tmp_path / "libdoc"
+        files = list(section_dir.iterdir())
+
+        assert len(files) == 1
+        assert files[0].suffix == ".pkl"
+
+    def test_read_corrupt_pickle_raises_error(self, tmp_path: Path) -> None:
+        """UnpicklingError is raised when pickle data is corrupt."""
+        cache = PickleDataCache(tmp_path)
+        cache_file = cache.build_cache_data_filename(CacheSection.LIBRARY, "corrupt")
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_bytes(b"not valid pickle data")
+
+        with pytest.raises((pickle.UnpicklingError, EOFError)):
+            cache.read_cache_data(CacheSection.LIBRARY, "corrupt", dict)
+
+    def test_different_sections_are_isolated(self, tmp_path: Path) -> None:
+        """Data in different sections doesn't interfere."""
+        cache = PickleDataCache(tmp_path)
+        cache.save_cache_data(CacheSection.LIBRARY, "same_name", {"section": "library"})
+        cache.save_cache_data(CacheSection.RESOURCE, "same_name", {"section": "resource"})
+
+        lib_data = cache.read_cache_data(CacheSection.LIBRARY, "same_name", dict)
+        res_data = cache.read_cache_data(CacheSection.RESOURCE, "same_name", dict)
+
+        assert lib_data["section"] == "library"
+        assert res_data["section"] == "resource"
+
+
+class TestJsonDataCache:
+    """Tests for JsonDataCache implementation."""
+
+    def test_build_cache_data_filename(self, tmp_path: Path) -> None:
+        """Filename uses .json extension."""
+        cache = JsonDataCache(tmp_path)
+
+        path = cache.build_cache_data_filename(CacheSection.LIBRARY, "test_entry")
+
+        assert path == tmp_path / "libdoc" / "test_entry.json"
+
+    def test_cache_data_exists(self, tmp_path: Path) -> None:
+        """cache_data_exists works for JSON cache."""
+        cache = JsonDataCache(tmp_path)
+
+        assert cache.cache_data_exists(CacheSection.LIBRARY, "test") is False
+
+        cache.save_cache_data(CacheSection.LIBRARY, "test", {"key": "value"})
+
+        assert cache.cache_data_exists(CacheSection.LIBRARY, "test") is True
+
+    def test_save_and_read_cache_data(self, tmp_path: Path) -> None:
+        """Save and read JSON data correctly."""
+        cache = JsonDataCache(tmp_path)
+        data = {"name": "test", "values": [1, 2, 3]}
+
+        cache.save_cache_data(CacheSection.LIBRARY, "test", data)
+        result = cache.read_cache_data(CacheSection.LIBRARY, "test", dict)
+
+        assert result == data
+
+
+class TestCacheEdgeCases:
+    """Edge case tests for cache implementations."""
+
+    @pytest.mark.parametrize(
+        "entry_name",
+        [
+            "simple",
+            "with_underscore",
+            "with-dash",
+            "with.dots",
+            "nested/path/entry",
+            "unicode_日本語",
+        ],
+    )
+    def test_various_entry_names(self, tmp_path: Path, entry_name: str) -> None:
+        """Cache handles various entry name formats."""
+        cache = PickleDataCache(tmp_path)
+        data = {"entry": entry_name}
+
+        cache.save_cache_data(CacheSection.LIBRARY, entry_name, data)
+        result = cache.read_cache_data(CacheSection.LIBRARY, entry_name, dict)
+
+        assert result == data
+
+    def test_large_data(self, tmp_path: Path) -> None:
+        """Cache handles large data objects."""
+        cache = PickleDataCache(tmp_path)
+        # Create ~1MB of data
+        data = {"items": list(range(100000)), "text": "x" * 500000}
+
+        cache.save_cache_data(CacheSection.NAMESPACE, "large", data)
+        result = cache.read_cache_data(CacheSection.NAMESPACE, "large", dict)
+
+        assert result == data
+
+    def test_none_value(self, tmp_path: Path) -> None:
+        """Cache handles None values."""
+        cache = PickleDataCache(tmp_path)
+
+        cache.save_cache_data(CacheSection.LIBRARY, "none_test", None)
+        result = cache.read_cache_data(CacheSection.LIBRARY, "none_test", type(None))
+
+        assert result is None
+
+    def test_empty_dict(self, tmp_path: Path) -> None:
+        """Cache handles empty dictionaries."""
+        cache = PickleDataCache(tmp_path)
+
+        cache.save_cache_data(CacheSection.LIBRARY, "empty", {})
+        result = cache.read_cache_data(CacheSection.LIBRARY, "empty", dict)
+
+        assert result == {}

--- a/tests/robotcode/robot/diagnostics/test_imports_manager_cache.py
+++ b/tests/robotcode/robot/diagnostics/test_imports_manager_cache.py
@@ -28,14 +28,16 @@ class TestResourceMetaData:
 
     def test_filepath_base_property(self) -> None:
         """filepath_base computes correct cache filename base."""
+        source = "/home/user/project/resources/common.resource"
         meta = ResourceMetaData(
             meta_version=RESOURCE_META_VERSION,
-            source="/home/user/project/resources/common.resource",
+            source=source,
             mtime=0,
         )
 
         # Should be "adler32hash_stem" format
-        expected_hash = f"{zlib.adler32(b'/home/user/project/resources'):08x}"
+        parent_path = str(Path(source).parent)
+        expected_hash = f"{zlib.adler32(parent_path.encode('utf-8')):08x}"
         assert meta.filepath_base == f"{expected_hash}_common"
 
     def test_filepath_base_different_paths(self) -> None:

--- a/tests/robotcode/robot/diagnostics/test_imports_manager_cache.py
+++ b/tests/robotcode/robot/diagnostics/test_imports_manager_cache.py
@@ -1,0 +1,180 @@
+"""Unit tests for imports_manager cache functionality."""
+
+import zlib
+from pathlib import Path
+
+import pytest
+
+from robotcode.robot.diagnostics.imports_manager import (
+    RESOURCE_META_VERSION,
+    ResourceMetaData,
+)
+
+
+class TestResourceMetaData:
+    """Tests for ResourceMetaData dataclass."""
+
+    def test_create_metadata(self) -> None:
+        """ResourceMetaData can be created with all required fields."""
+        meta = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/path/to/resource.resource",
+            mtime=1234567890123456789,
+        )
+
+        assert meta.meta_version == RESOURCE_META_VERSION
+        assert meta.source == "/path/to/resource.resource"
+        assert meta.mtime == 1234567890123456789
+
+    def test_filepath_base_property(self) -> None:
+        """filepath_base computes correct cache filename base."""
+        meta = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/home/user/project/resources/common.resource",
+            mtime=0,
+        )
+
+        # Should be "adler32hash_stem" format
+        expected_hash = f"{zlib.adler32(b'/home/user/project/resources'):08x}"
+        assert meta.filepath_base == f"{expected_hash}_common"
+
+    def test_filepath_base_different_paths(self) -> None:
+        """filepath_base generates unique hashes for different parent directories."""
+        meta1 = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/path/a/resource.resource",
+            mtime=0,
+        )
+        meta2 = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/path/b/resource.resource",
+            mtime=0,
+        )
+
+        # Different parent dirs should produce different hashes
+        assert meta1.filepath_base != meta2.filepath_base
+        # But both end with the same stem
+        assert meta1.filepath_base.endswith("_resource")
+        assert meta2.filepath_base.endswith("_resource")
+
+    def test_filepath_base_same_name_different_dirs(self) -> None:
+        """Same filename in different directories produces different cache keys."""
+        meta1 = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/project/tests/keywords.resource",
+            mtime=0,
+        )
+        meta2 = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/project/lib/keywords.resource",
+            mtime=0,
+        )
+
+        assert meta1.filepath_base != meta2.filepath_base
+
+    def test_metadata_equality(self) -> None:
+        """ResourceMetaData instances are equal when all fields match."""
+        meta1 = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/path/to/resource.resource",
+            mtime=12345,
+        )
+        meta2 = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/path/to/resource.resource",
+            mtime=12345,
+        )
+
+        assert meta1 == meta2
+
+    def test_metadata_inequality_different_mtime(self) -> None:
+        """ResourceMetaData instances differ when mtime differs."""
+        meta1 = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/path/to/resource.resource",
+            mtime=12345,
+        )
+        meta2 = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/path/to/resource.resource",
+            mtime=67890,
+        )
+
+        assert meta1 != meta2
+
+    def test_metadata_inequality_different_source(self) -> None:
+        """ResourceMetaData instances differ when source differs."""
+        meta1 = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/path/a/resource.resource",
+            mtime=12345,
+        )
+        meta2 = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/path/b/resource.resource",
+            mtime=12345,
+        )
+
+        assert meta1 != meta2
+
+
+class TestResourceMetaVersion:
+    """Tests for RESOURCE_META_VERSION constant."""
+
+    def test_meta_version_is_string(self) -> None:
+        """Meta version is a string."""
+        assert isinstance(RESOURCE_META_VERSION, str)
+        assert len(RESOURCE_META_VERSION) > 0
+
+    def test_meta_version_value(self) -> None:
+        """Meta version has expected value."""
+        assert RESOURCE_META_VERSION == "1"
+
+
+class TestCacheKeyGeneration:
+    """Tests for cache key generation patterns."""
+
+    @pytest.mark.parametrize(
+        ("source", "expected_stem"),
+        [
+            ("/path/to/test.resource", "_test"),
+            ("/path/to/common_keywords.resource", "_common_keywords"),
+            ("/path/to/My-Library.resource", "_My-Library"),
+            ("/path/日本語/テスト.resource", "_テスト"),
+        ],
+    )
+    def test_cache_key_stem_extraction(self, source: str, expected_stem: str) -> None:
+        """Cache key correctly extracts filename stem."""
+        meta = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source=source,
+            mtime=0,
+        )
+
+        assert meta.filepath_base.endswith(expected_stem)
+
+    def test_cache_key_uses_adler32(self) -> None:
+        """Cache key uses zlib.adler32 for parent directory hash."""
+        source = "/specific/path/to/resource.resource"
+        meta = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source=source,
+            mtime=0,
+        )
+
+        parent_path = str(Path(source).parent)
+        expected_hash = f"{zlib.adler32(parent_path.encode('utf-8')):08x}"
+
+        assert meta.filepath_base.startswith(expected_hash)
+
+    def test_cache_key_hash_length(self) -> None:
+        """Cache key hash portion is 8 hex characters (adler32)."""
+        meta = ResourceMetaData(
+            meta_version=RESOURCE_META_VERSION,
+            source="/any/path/file.resource",
+            mtime=0,
+        )
+
+        hash_part = meta.filepath_base.split("_")[0]
+        assert len(hash_part) == 8
+        assert all(c in "0123456789abcdef" for c in hash_part)

--- a/tests/robotcode/robot/diagnostics/test_namespace_cache.py
+++ b/tests/robotcode/robot/diagnostics/test_namespace_cache.py
@@ -1,0 +1,370 @@
+"""Unit tests for namespace caching data classes and serialization."""
+
+import hashlib
+import zlib
+from pathlib import Path
+
+import pytest
+
+from robotcode.core.lsp.types import Position, Range
+from robotcode.robot.diagnostics.namespace import (
+    NAMESPACE_META_VERSION,
+    CachedLibraryEntry,
+    CachedResourceEntry,
+    CachedVariablesEntry,
+    Namespace,
+    NamespaceCacheData,
+    NamespaceMetaData,
+)
+
+
+class TestNamespaceMetaData:
+    """Tests for NamespaceMetaData dataclass."""
+
+    def test_create_metadata(self) -> None:
+        """NamespaceMetaData can be created with all required fields."""
+        meta = NamespaceMetaData(
+            meta_version=NAMESPACE_META_VERSION,
+            source="/path/to/test.robot",
+            mtime=1234567890123456789,
+            file_size=1024,
+            content_hash="abc123",
+            library_sources_mtimes=(("/path/lib.py", 111),),
+            resource_sources_mtimes=(("/path/res.resource", 222),),
+            variables_sources_mtimes=(("/path/vars.py", 333),),
+            robot_version="7.0",
+            python_executable="/usr/bin/python3",
+            sys_path_hash="def456",
+        )
+
+        assert meta.meta_version == NAMESPACE_META_VERSION
+        assert meta.source == "/path/to/test.robot"
+        assert meta.mtime == 1234567890123456789
+        assert meta.file_size == 1024
+        assert meta.content_hash == "abc123"
+
+    def test_metadata_is_frozen(self) -> None:
+        """NamespaceMetaData is immutable."""
+        meta = NamespaceMetaData(
+            meta_version=NAMESPACE_META_VERSION,
+            source="/path/to/test.robot",
+            mtime=1234567890,
+            file_size=100,
+            content_hash="abc",
+            library_sources_mtimes=(),
+            resource_sources_mtimes=(),
+            variables_sources_mtimes=(),
+            robot_version="7.0",
+            python_executable="/usr/bin/python3",
+            sys_path_hash="def",
+        )
+
+        with pytest.raises(AttributeError):
+            meta.source = "/other/path"  # type: ignore[misc]
+
+    def test_filepath_base_property(self) -> None:
+        """filepath_base computes correct cache filename base."""
+        meta = NamespaceMetaData(
+            meta_version=NAMESPACE_META_VERSION,
+            source="/home/user/project/tests/test_example.robot",
+            mtime=1234567890,
+            file_size=100,
+            content_hash="abc",
+            library_sources_mtimes=(),
+            resource_sources_mtimes=(),
+            variables_sources_mtimes=(),
+            robot_version="7.0",
+            python_executable="/usr/bin/python3",
+            sys_path_hash="def",
+        )
+
+        # Should be "adler32hash_stem" format
+        expected_hash = f"{zlib.adler32(b'/home/user/project/tests'):08x}"
+        assert meta.filepath_base == f"{expected_hash}_test_example"
+
+    def test_filepath_base_with_different_paths(self) -> None:
+        """filepath_base generates unique hashes for different parent directories."""
+        meta1 = NamespaceMetaData(
+            meta_version=NAMESPACE_META_VERSION,
+            source="/path/a/test.robot",
+            mtime=0,
+            file_size=0,
+            content_hash="",
+            library_sources_mtimes=(),
+            resource_sources_mtimes=(),
+            variables_sources_mtimes=(),
+            robot_version="7.0",
+            python_executable="",
+            sys_path_hash="",
+        )
+        meta2 = NamespaceMetaData(
+            meta_version=NAMESPACE_META_VERSION,
+            source="/path/b/test.robot",
+            mtime=0,
+            file_size=0,
+            content_hash="",
+            library_sources_mtimes=(),
+            resource_sources_mtimes=(),
+            variables_sources_mtimes=(),
+            robot_version="7.0",
+            python_executable="",
+            sys_path_hash="",
+        )
+
+        # Different parent dirs should produce different hashes
+        assert meta1.filepath_base != meta2.filepath_base
+        # But both end with the same stem
+        assert meta1.filepath_base.endswith("_test")
+        assert meta2.filepath_base.endswith("_test")
+
+
+class TestCachedEntryClasses:
+    """Tests for cached entry dataclasses."""
+
+    def test_cached_library_entry(self) -> None:
+        """CachedLibraryEntry can be created with all fields."""
+        entry = CachedLibraryEntry(
+            name="Collections",
+            import_name="Collections",
+            library_doc_source="/path/to/collections.py",
+            args=(),
+            alias=None,
+            import_range=Range(start=Position(line=0, character=0), end=Position(line=0, character=11)),
+            import_source="/test.robot",
+            alias_range=Range.zero(),
+        )
+
+        assert entry.name == "Collections"
+        assert entry.import_name == "Collections"
+        assert entry.library_doc_source == "/path/to/collections.py"
+
+    def test_cached_library_entry_with_alias(self) -> None:
+        """CachedLibraryEntry supports alias."""
+        entry = CachedLibraryEntry(
+            name="MyAlias",
+            import_name="SomeLibrary",
+            library_doc_source="/path/to/lib.py",
+            args=("arg1", "arg2"),
+            alias="MyAlias",
+            import_range=Range.zero(),
+            import_source="/test.robot",
+            alias_range=Range(start=Position(line=0, character=20), end=Position(line=0, character=27)),
+        )
+
+        assert entry.alias == "MyAlias"
+        assert entry.args == ("arg1", "arg2")
+
+    def test_cached_resource_entry(self) -> None:
+        """CachedResourceEntry includes imports and variables."""
+        entry = CachedResourceEntry(
+            name="common",
+            import_name="resources/common.resource",
+            library_doc_source="/project/resources/common.resource",
+            args=(),
+            alias=None,
+            import_range=Range.zero(),
+            import_source="/test.robot",
+            alias_range=Range.zero(),
+            imports=(),
+            variables=(),
+        )
+
+        assert entry.name == "common"
+        assert entry.imports == ()
+        assert entry.variables == ()
+
+    def test_cached_variables_entry(self) -> None:
+        """CachedVariablesEntry includes variables."""
+        entry = CachedVariablesEntry(
+            name="vars",
+            import_name="variables.py",
+            library_doc_source="/project/variables.py",
+            args=(),
+            alias=None,
+            import_range=Range.zero(),
+            import_source="/test.robot",
+            alias_range=Range.zero(),
+            variables=(),
+        )
+
+        assert entry.name == "vars"
+        assert entry.variables == ()
+
+    def test_cached_entries_are_frozen(self) -> None:
+        """All cached entry types are immutable."""
+        lib_entry = CachedLibraryEntry(
+            name="Test",
+            import_name="Test",
+            library_doc_source=None,
+            args=(),
+            alias=None,
+            import_range=Range.zero(),
+            import_source=None,
+            alias_range=Range.zero(),
+        )
+
+        with pytest.raises(AttributeError):
+            lib_entry.name = "Modified"  # type: ignore[misc]
+
+
+class TestNamespaceCacheData:
+    """Tests for NamespaceCacheData dataclass."""
+
+    def test_create_minimal_cache_data(self) -> None:
+        """NamespaceCacheData can be created with minimal data."""
+        cache_data = NamespaceCacheData(
+            libraries=(),
+            resources=(),
+            resources_files=(),
+            variables_imports=(),
+            own_variables=(),
+            imports=(),
+            library_doc=None,
+        )
+
+        assert cache_data.libraries == ()
+        assert cache_data.analyzed is False
+        assert cache_data.diagnostics == ()
+
+    def test_cache_data_with_analysis_results(self) -> None:
+        """NamespaceCacheData includes analysis data when analyzed=True."""
+        cache_data = NamespaceCacheData(
+            libraries=(),
+            resources=(),
+            resources_files=(),
+            variables_imports=(),
+            own_variables=(),
+            imports=(),
+            library_doc=None,
+            analyzed=True,
+            diagnostics=(),
+            test_case_definitions=(),
+            tag_definitions=(),
+            namespace_references=(),
+        )
+
+        assert cache_data.analyzed is True
+
+    def test_cache_data_is_frozen(self) -> None:
+        """NamespaceCacheData is immutable."""
+        cache_data = NamespaceCacheData(
+            libraries=(),
+            resources=(),
+            resources_files=(),
+            variables_imports=(),
+            own_variables=(),
+            imports=(),
+            library_doc=None,
+        )
+
+        with pytest.raises(AttributeError):
+            cache_data.analyzed = True  # type: ignore[misc]
+
+
+class TestComputeContentHash:
+    """Tests for Namespace._compute_content_hash static method."""
+
+    def test_compute_hash_small_file(self, tmp_path: Path) -> None:
+        """Content hash is computed for small files (< 64KB)."""
+        test_file = tmp_path / "small.robot"
+        content = b"*** Test Cases ***\nTest\n    Log    Hello"
+        test_file.write_bytes(content)
+
+        file_size, content_hash = Namespace._compute_content_hash(test_file)
+
+        assert file_size == len(content)
+        assert len(content_hash) == 64  # SHA256 hex digest length
+        assert content_hash == hashlib.sha256(f"{len(content)}:".encode() + content).hexdigest()
+
+    def test_compute_hash_large_file(self, tmp_path: Path) -> None:
+        """Content hash includes first and last 64KB for large files."""
+        test_file = tmp_path / "large.robot"
+        # Create file > 64KB: 100KB of content
+        first_part = b"A" * 65536
+        middle_part = b"B" * 20000
+        last_part = b"C" * 65536
+        content = first_part + middle_part + last_part
+        test_file.write_bytes(content)
+
+        file_size, content_hash = Namespace._compute_content_hash(test_file)
+
+        assert file_size == len(content)
+        # Verify hash includes size + first 64KB + last 64KB
+        expected_hasher = hashlib.sha256()
+        expected_hasher.update(f"{len(content)}:".encode())
+        expected_hasher.update(first_part)
+        expected_hasher.update(content[-65536:])  # Last 64KB
+        assert content_hash == expected_hasher.hexdigest()
+
+    def test_different_content_different_hash(self, tmp_path: Path) -> None:
+        """Different file content produces different hashes."""
+        file1 = tmp_path / "file1.robot"
+        file2 = tmp_path / "file2.robot"
+        file1.write_bytes(b"Content A")
+        file2.write_bytes(b"Content B")
+
+        _, hash1 = Namespace._compute_content_hash(file1)
+        _, hash2 = Namespace._compute_content_hash(file2)
+
+        assert hash1 != hash2
+
+    def test_same_content_same_hash(self, tmp_path: Path) -> None:
+        """Same file content produces same hash."""
+        file1 = tmp_path / "file1.robot"
+        file2 = tmp_path / "file2.robot"
+        content = b"Same content in both files"
+        file1.write_bytes(content)
+        file2.write_bytes(content)
+
+        _, hash1 = Namespace._compute_content_hash(file1)
+        _, hash2 = Namespace._compute_content_hash(file2)
+
+        assert hash1 == hash2
+
+    def test_append_detection(self, tmp_path: Path) -> None:
+        """Hash detects appended content (size change)."""
+        test_file = tmp_path / "test.robot"
+        original = b"Original content"
+        test_file.write_bytes(original)
+        size1, hash1 = Namespace._compute_content_hash(test_file)
+
+        # Append content
+        test_file.write_bytes(original + b"\nAppended line")
+        size2, hash2 = Namespace._compute_content_hash(test_file)
+
+        assert size2 > size1
+        assert hash1 != hash2
+
+    def test_modification_detection(self, tmp_path: Path) -> None:
+        """Hash detects in-place modification (same size, different content)."""
+        test_file = tmp_path / "test.robot"
+        test_file.write_bytes(b"Original content here")
+        _, hash1 = Namespace._compute_content_hash(test_file)
+
+        # Modify without changing size
+        test_file.write_bytes(b"Modified content here")
+        _, hash2 = Namespace._compute_content_hash(test_file)
+
+        assert hash1 != hash2
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        """Hash handles empty files."""
+        test_file = tmp_path / "empty.robot"
+        test_file.write_bytes(b"")
+
+        file_size, content_hash = Namespace._compute_content_hash(test_file)
+
+        assert file_size == 0
+        assert len(content_hash) == 64
+
+
+class TestMetaVersion:
+    """Tests for namespace meta version constant."""
+
+    def test_meta_version_format(self) -> None:
+        """Meta version is a valid version string."""
+        assert NAMESPACE_META_VERSION == "1.0"
+        # Verify it can be parsed as a version
+        parts = NAMESPACE_META_VERSION.split(".")
+        assert len(parts) == 2
+        assert all(part.isdigit() for part in parts)

--- a/tests/robotcode/robot/diagnostics/test_namespace_cache.py
+++ b/tests/robotcode/robot/diagnostics/test_namespace_cache.py
@@ -64,9 +64,10 @@ class TestNamespaceMetaData:
 
     def test_filepath_base_property(self) -> None:
         """filepath_base computes correct cache filename base."""
+        source = "/home/user/project/tests/test_example.robot"
         meta = NamespaceMetaData(
             meta_version=NAMESPACE_META_VERSION,
-            source="/home/user/project/tests/test_example.robot",
+            source=source,
             mtime=1234567890,
             file_size=100,
             content_hash="abc",
@@ -79,7 +80,8 @@ class TestNamespaceMetaData:
         )
 
         # Should be "adler32hash_stem" format
-        expected_hash = f"{zlib.adler32(b'/home/user/project/tests'):08x}"
+        parent_path = str(Path(source).parent)
+        expected_hash = f"{zlib.adler32(parent_path.encode('utf-8')):08x}"
         assert meta.filepath_base == f"{expected_hash}_test_example"
 
     def test_filepath_base_with_different_paths(self) -> None:


### PR DESCRIPTION
## Summary

This PR implements a comprehensive performance improvement plan that dramatically reduces Language Server startup time and improves edit responsiveness.

- Reuse the executor for library loading instead of spawning new processes
- Cache resource `LibraryDoc` objects to `.robotcode_cache/*/resource/`
- Only invalidate namespaces that actually import the changed file
- Allow up to 4 concurrent library loads (`max_workers=min(cpu_count, 4)`)
- O(1) lookup for documents importing a given source via reverse dependency map
- `get_library_users()` and `get_variables_users()` for instant change propagation
- Persist namespace initialization state to disk
- Skip full import resolution on warm starts

### Testing Plan

- 28 unit tests for PickleDataCache atomic writes
- 20 unit tests for NamespaceMetaData and cached entries
- 15 unit tests for ResourceMetaData cache keys
- 11 integration tests for namespace caching behavior

### Architecture

#### Architecture Overview

```mermaid
flowchart TB
    subgraph cache["Disk Cache (.robotcode_cache/)"]
        lib["libdoc/<br/>Library docs"]
        res["resource/<br/>Resource docs"]
        ns["namespace/<br/>Namespace state"]
    end

    subgraph perf["Performance Optimizations"]
        p1["Shared Process Pool"]
        p2["Resource Caching"]
        p3["Targeted Invalidation"]
        p4["Parallel Library Loading"]
        p5["O(1) Dependency Lookups"]
        p7["Namespace Caching"]
        p9["Atomic Writes"]
    end

    subgraph maps["Reverse Dependency Maps"]
        imp["_importers<br/>source → documents"]
        lu["_library_users<br/>lib → documents"]
        vu["_variables_users<br/>var → documents"]
    end

    p1 --> lib
    p2 --> res
    p7 --> ns
    p9 --> ns
    p3 --> imp
    p5 --> lu
    p5 --> vu
```

#### Cold vs Warm Start Flow

```mermaid
flowchart TB
    subgraph startup["IDE Startup"]
        open["User Opens VS Code"]
    end

    subgraph cold["Cold Start (No Cache) ~2-4 min"]
        c1["Parse .robot files"]
        c2["Resolve imports in parallel"]
        c3["Load libraries<br/>(shared executor)"]
        c4["Build namespaces"]
        c5["Save to cache<br/>(atomic write)"]
        c1 --> c2 --> c3 --> c4 --> c5
    end

    subgraph warm["Warm Start (Cache Hit) ~10-20 sec"]
        w1["Check .cache.pkl exists"]
        w2{"Validate:<br/>mtime + size?"}
        w3["Load (meta, spec)"]
        w4["Check environment identity"]
        w5["Restore namespace"]
        w1 --> w2
        w2 -->|"Match"| w3 --> w4 --> w5
        w2 -->|"Changed"| miss["Rebuild"]
    end

    subgraph runtime["Runtime Editing"]
        r1["File changed"]
        r2["O(1) lookup affected docs"]
        r3["Targeted invalidation"]
        r4["Rebuild only affected"]
        r1 --> r2 --> r3 --> r4
    end

    open --> cold
    open --> warm
    
    style cold fill:#ffcccc,stroke:#cc0000
    style warm fill:#ccffcc,stroke:#00cc00
    style runtime fill:#cce5ff,stroke:#0066cc
```

#### Cache Validation Chain

```mermaid
sequenceDiagram
    participant LS as Language Server
    participant Cache as Disk Cache
    participant FS as File System

    Note over LS,FS: Warm Start Validation
    
    LS->>Cache: Load .cache.pkl
    Cache-->>LS: (meta, spec) tuple
    
    LS->>FS: stat(source_file)
    FS-->>LS: mtime, size
    
    alt mtime matches
        alt size matches
            Note over LS: Skip content hash!<br/>(Fast path)
            LS->>LS: Check python_executable
            LS->>LS: Check sys_path_hash
            alt Environment matches
                LS->>LS: Restore from cache ✓
            else Environment changed
                LS->>LS: Rebuild namespace
            end
        else size differs
            LS->>FS: Read first+last 64KB
            FS-->>LS: content chunks
            LS->>LS: Compute tiered hash
            alt Hash matches
                LS->>LS: Restore from cache ✓
            else Hash differs
                LS->>LS: Rebuild namespace
            end
        end
    else mtime differs
        LS->>LS: Rebuild namespace
    end
```





