### PR TITLE
feat(robocop): Robocop 8.0 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ cd intellij-client
 hatch run test
 
 # Test specific environment
-hatch run devel.py3.12-rf73:test
+hatch run devel.py312-rf73:test
 
 # Coverage reporting
 hatch run cov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,7 @@ You can also check available environments with: `hatch env show`
 
 1. **Create a branch:** `git checkout -b feature/your-feature-name`
 2. **Make your changes** following the project's coding standards
-3. **Run tests:** `hatch run devel.py3.12-rf73:test` (single combination for faster development)
+3. **Run tests:** `hatch run devel.py312-rf73:test` (single combination for faster development)
 4. **Run linting:** `hatch run lint:all` (or use the VS Code task)
 5. **Fix linting issues:** `hatch run lint:style` for formatting
 6. **Commit your changes** with a descriptive commit message
@@ -297,23 +297,20 @@ hatch run test.rf41:test      # Robot Framework 4.1.x
 
 # Run tests in specific development environments (single combination)
 hatch run devel:test          # ⚠️ Runs ALL matrix combinations (Python 3.10-3.14 × RF 4.1-7.3)
-hatch run devel.py3.11-rf70:test # Python 3.11 with Robot Framework 7.0.x (single combination)
-hatch run devel.py3.12-rf73:test # Python 3.12 with Robot Framework 7.3.x (single combination)
-hatch run devel.py3.13-rf73:test # Python 3.13 with Robot Framework 7.3.x (single combination)
+hatch run devel.py311-rf70:test # Python 3.11 with Robot Framework 7.0.x (single combination)
+hatch run devel.py312-rf73:test # Python 3.12 with Robot Framework 7.3.x (single combination)
+hatch run devel.py313-rf73:test # Python 3.13 with Robot Framework 7.3.x (single combination)
 
 # Test against development versions of Robot Framework
 hatch run rfbeta:test         # Robot Framework beta/RC versions
 hatch run rfmaster:test       # Robot Framework master branch
 hatch run rfdevel:test        # Local Robot Framework development version
-
-# Test with Robocop development version
-hatch run robocopmain:test  # Robocop main branch
 ```
 
 **⚠️ Important Matrix Behavior:**
 - `hatch run test` executes tests for **all combinations** in the matrix (48 combinations: 6 Python versions × 8 RF versions)
 - `hatch run devel:test` also runs **all matrix combinations**
-- For faster development, use specific combinations like `hatch run devel.py3.12-rf73:test`
+- For faster development, use specific combinations like `hatch run devel.py312-rf73:test`
 - For CI/full testing, use the matrix commands
 
 **Available Environment Matrix:**

--- a/hatch.toml
+++ b/hatch.toml
@@ -49,13 +49,7 @@ extra-dependencies = ["robotframework==7.2rc1"]
 [envs.rfmaster]
 python = "3.12"
 extra-dependencies = [
-  "robotframework @ git+https://github.com/robotframework/robotframework.git"
-]
-
-[envs.robocopmain]
-python = "3.12"
-extra-dependencies = [
-  "robotframework-robocop @ git+https://github.com/MarketSquare/robotframework-robocop.git"
+  "robotframework @ git+https://github.com/robotframework/robotframework.git",
 ]
 
 [envs.rfdevel]

--- a/packages/language_server/src/robotcode/language_server/robotframework/parts/robocop_helper.py
+++ b/packages/language_server/src/robotcode/language_server/robotframework/parts/robocop_helper.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from ..protocol import RobotLanguageServerProtocol
 
 if TYPE_CHECKING:
-    from robocop.config import ConfigManager
+    from robocop.config.manager import ConfigManager
 
 
 class RobocopConfigError(Exception):
@@ -59,7 +59,10 @@ class RoboCopHelper(RobotLanguageServerProtocolPart):
         return self.parent.workspace.get_configuration(RoboCopConfig, folder.uri)
 
     def get_config_manager(self, workspace_folder: WorkspaceFolder) -> "ConfigManager":
-        from robocop.config import ConfigManager
+        if self.parent.robocop_helper.robocop_version >= (8, 0):
+            from robocop.config.manager import ConfigManager
+        else:
+            from robocop.config import ConfigManager
 
         if workspace_folder in self._config_managers:
             return self._config_managers[workspace_folder]


### PR DESCRIPTION
Robocop 8.0 brings several changes. One of them is breaking change in interface to run_check / format_until_stable which now accepts ``SourceFile`` instead of separate path / model / config files. This PR changes the method invocation to reflect it.

Note that 8.0 is still not released but should go live tommorrow. The other changes should not affect Robotcode directly. I have tested with old 7.2 and not released 8.0 (installed directly from our github).

Other minor changes:

- I used codespace and run your tests. I couldn't find "hatch run devel.py312-rf73:test" env to run, but the one with dot works - so I changed your docs to reflect it
- Added Robocop development environment to hatch, to test not yet released changes (for future, if needed)