### PR TITLE
perf(analyze): Targeted caching optimization

### DIFF
--- a/packages/core/src/robotcode/core/utils/path.py
+++ b/packages/core/src/robotcode/core/utils/path.py
@@ -62,7 +62,7 @@ def normalized_path_full(path: Union[str, "os.PathLike[str]"]) -> Path:
     return Path(*parents)
 
 
-@functools.cache
+@functools.lru_cache(maxsize=100_000)
 def same_file(path1: Union[str, "os.PathLike[str]", Path], path2: Union[str, "os.PathLike[str]", Path]) -> bool:
     try:
         return os.path.samefile(path1, path2)

--- a/packages/core/src/robotcode/core/utils/path.py
+++ b/packages/core/src/robotcode/core/utils/path.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import re
 import sys
@@ -61,6 +62,7 @@ def normalized_path_full(path: Union[str, "os.PathLike[str]"]) -> Path:
     return Path(*parents)
 
 
+@functools.cache
 def same_file(path1: Union[str, "os.PathLike[str]", Path], path2: Union[str, "os.PathLike[str]", Path]) -> bool:
     try:
         return os.path.samefile(path1, path2)

--- a/packages/robot/src/robotcode/robot/utils/variables.py
+++ b/packages/robot/src/robotcode/robot/utils/variables.py
@@ -215,7 +215,7 @@ def is_variable(string: str, identifiers: str = "$@&") -> bool:
     return cast(bool, robot_is_variable(string, identifiers))
 
 
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=100_000)
 def search_variable(
     string: str, identifiers: str = "$@&%*", parse_type: bool = False, ignore_errors: bool = False
 ) -> VariableMatcher:


### PR DESCRIPTION
After our discussion at Robocon I was curious what takes the most time in Robotcode.

During profiling I came across 2 situations that significantly slowed down code analysis in my ~600 file project.

`same_file()` took significant time. After slapping a `functools.lru_cache` on it, my runtime went down with about 8 minutes!
from: `Files: 650, Errors: 1403, Warnings: 13, Infos: 552, Hints: 2709 (in 11m 0.14s)`
to: `Files: 650, Errors: 1403, Warnings: 13, Infos: 552, Hints: 2709 (in 2m 55.07s)`

`search_variable()` wasn't as big a time sink, but I knew that this project contains a lot of global vars. According to `robotunused` it contains 31102 non-local variables. So the old cache limit of 1024 seemed small to me. After upping it significantly to 100.000, it runs 37 seconds faster.
from: `Files: 650, Errors: 1403, Warnings: 13, Infos: 552, Hints: 2709 (in 2m 55.07s)`
to: `Files: 650, Errors: 1403, Warnings: 13, Infos: 552, Hints: 2709 (in 2m 18.07s)`

These are some nice time savings for such small changes.

@d-biehl I did consider memory footprint too. Do you think it makes sense to add a cache size config thing? Or maybe replace `lru_cache` with something more sophisticated and more configurable?